### PR TITLE
fix: 사용자 로그인 아이디 username으로 수정 및 controller 수정

### DIFF
--- a/src/main/java/com/DrWait/core/security/auth/controller/AuthController.java
+++ b/src/main/java/com/DrWait/core/security/auth/controller/AuthController.java
@@ -1,8 +1,8 @@
 package com.DrWait.core.security.auth.controller;
 
-import com.DrWait.core.security.auth.dto.HospitalSignupRequestDto;
 import com.DrWait.core.security.auth.dto.LoginRequestDto;
 import com.DrWait.core.security.auth.dto.LoginResponseDto;
+import com.DrWait.core.security.auth.dto.SignupRequestDto;
 import com.DrWait.core.security.auth.sesrvice.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,14 +17,14 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/signup")
-    public ResponseEntity<?> signup(@RequestBody HospitalSignupRequestDto request){
-        authService.hospitalSignup(request);
+    public ResponseEntity<?> signup(@RequestBody SignupRequestDto request){
+        authService.signup(request);
         return ResponseEntity.ok("회원가입 성공");
     }
 
     @PostMapping("/login")
     public ResponseEntity<LoginResponseDto> login(@RequestBody LoginRequestDto request){
-        return ResponseEntity.ok(authService.hospitalLogin(request));
+        return ResponseEntity.ok(authService.login(request));
     }
 
     @PostMapping("/reissue")

--- a/src/main/java/com/DrWait/core/security/auth/dto/SignupRequestDto.java
+++ b/src/main/java/com/DrWait/core/security/auth/dto/SignupRequestDto.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 public class SignupRequestDto {
 
     private String username;
-    private String email;
     private String password;
     private String phoneNumber;
     private String residentRegistrationNumber;

--- a/src/main/java/com/DrWait/core/security/auth/sesrvice/AuthService.java
+++ b/src/main/java/com/DrWait/core/security/auth/sesrvice/AuthService.java
@@ -28,9 +28,9 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
 
     public void signup(SignupRequestDto request){
-        // 1. 이메일 중복 체크
-        if(userRepository.existsByEmail(request.getUsername())){
-            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+        // 1. 사용자 아이디 중복 체크
+        if(userRepository.existsByUsername(request.getUsername())){
+            throw new IllegalArgumentException("이미 존재하는 계정입니다.");
         }
 
         // 2. 비밀번호 암호화
@@ -38,7 +38,6 @@ public class AuthService {
 
         User user = User.builder()
                 .username(request.getUsername())
-                .email(request.getEmail())
                 .password(encodedPassword)
                 .phoneNumber(request.getPhoneNumber())
                 .residentRegistrationNumber(request.getResidentRegistrationNumber())
@@ -49,7 +48,7 @@ public class AuthService {
     }
 
     public void hospitalSignup(HospitalSignupRequestDto request){
-        // 1. 이메일 중복 체크
+        // 1. 사용자 아이디 중복체크
         if(hospitalRepository.existsByUsername(request.getUsername())){
             throw new IllegalArgumentException("이미 존재하는 계정입니다.");
         }
@@ -71,8 +70,8 @@ public class AuthService {
     }
 
     public LoginResponseDto login(LoginRequestDto request){
-        User user = userRepository.findByEmail(request.getUsername()) // 개인은 이메일, 병원은 username?
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
+        User user = userRepository.findByUsername(request.getUsername())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 계정입니다."));
 
         if(!passwordEncoder.matches(request.getPassword(), user.getPassword())){
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");

--- a/src/main/java/com/DrWait/domain/user/entity/User.java
+++ b/src/main/java/com/DrWait/domain/user/entity/User.java
@@ -21,13 +21,6 @@ public class User {
     @Column(nullable = false, length = 50)
     private String username;
 
-    @Column(name = "user_email",
-            nullable = false,
-            unique = true,
-            length = 50
-    )
-    private String email;
-
     @Column(nullable = false)
     private String password;
 

--- a/src/main/java/com/DrWait/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/DrWait/domain/user/repository/UserRepository.java
@@ -9,8 +9,8 @@ import java.util.UUID;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findById(UUID id);
-    Optional<User> findByEmail(String email);
+    Optional<User> findByUsername(String username);
 
     // 존재 여부만 확인하는 용도
-    boolean existsByEmail(String email);
+    boolean existsByUsername(String username);
 }


### PR DESCRIPTION
1. 기존 사용자 로그인의 아이디 였던 email을 username으로 통합시켰습니다.

2. 따라서 user 테이블에 email도 함께 삭제했습니다.

3. 작업 중 사용자 auth controller 에서 병원측 로그인/회원가입으로 연동되어있는 걸 확인해 수정했습니다.